### PR TITLE
Handle postgres constraints errors.

### DIFF
--- a/lib/formatter.ex
+++ b/lib/formatter.ex
@@ -198,6 +198,7 @@ defmodule JUnitFormatter do
     formatted_stack = Exception.format_stacktrace(stacktrace)
     message =
       case reason do
+        %{postgres: postgresError} -> "Postgres: in table " <> postgresError.table <> ", " <> postgresError.message
         %{message: message} -> message
         other -> inspect(other)
       end

--- a/lib/formatter.ex
+++ b/lib/formatter.ex
@@ -198,7 +198,7 @@ defmodule JUnitFormatter do
     formatted_stack = Exception.format_stacktrace(stacktrace)
     message =
       case reason do
-        %{postgres: postgresError} -> "Postgres: in table " <> postgresError.table <> ", " <> postgresError.message
+        %{message: nil} -> inspect(reason)
         %{message: message} -> message
         other -> inspect(other)
       end

--- a/test/formatter_test.exs
+++ b/test/formatter_test.exs
@@ -82,6 +82,24 @@ defmodule FormatterTest do
     assert output =~ "<testcase classname=\"Elixir.FormatterTest.RaiseWithNoReason\" name=\"test it raises without reason\" ><failure message=\"throw: nil\">    test/formatter_test.exs FormatterTest.RaiseWithNoReason.\"test it raises without reason\"/1\n</failure></testcase>"
   end
 
+  test "it can handle empty message" do
+    defmodule NilMessageError do
+      defexception [message: nil, customMessage: "A custom error occured !"]
+    end
+
+    defmodule RaiseWithNoMessage do
+      use ExUnit.Case
+
+      test "it raises without message" do
+        raise NilMessageError
+      end
+    end
+
+    output = run_and_capture_output |> strip_time_and_line_number
+
+    assert output =~ "<testcase classname=\"Elixir.FormatterTest.RaiseWithNoMessage\" name=\"test it raises without message\" ><failure message=\"error: %FormatterTest.NilMessageError{customMessage: &quot;A custom error occured !&quot;, message: nil}\">    test/formatter_test.exs FormatterTest.RaiseWithNoMessage.\"test it raises without message\"/1\n</failure></testcase>"
+  end
+
   test "it can format time" do
     assert JUnitFormatter.format_time(1000000) == "1.0"
     assert JUnitFormatter.format_time(10000) == "0.01"


### PR DESCRIPTION
I've got the same issue as @KronicDeth in #13 and in my case it was an incorrect handle of Postgres error which provides a nil message but got a message in a sub-attribute.

Feel free to modify the customized message ;)