### PR TITLE
Add skip test and tidies up function calls

### DIFF
--- a/lib/formatter.ex
+++ b/lib/formatter.ex
@@ -57,6 +57,7 @@ defmodule JUnitFormatter do
   end
 
   ## Formatter callbacks: may use opts in the future to configure file name pattern
+    
   def init(_opts), do: {:ok, []}
 
   def handle_event({:suite_finished, _run_us, _load_us}, config) do
@@ -120,6 +121,7 @@ defmodule JUnitFormatter do
   end
 
   @doc "Formats time from nanos to seconds"
+  @spec format_time(integer) :: integer
   def format_time(time), do: time |> us_to_ms |> format_ms
 
   @doc """
@@ -128,6 +130,7 @@ defmodule JUnitFormatter do
   - report_dir: full path of a directory (defaults to `Mix.Project.app_path()`)
   - report_file: name of the generated file (defaults to "test-junit-report.xml")
   """
+  @spec get_report_file_path() :: String.t
   def get_report_file_path() do
     report_file = Application.get_env :junit_formatter, :report_file, "test-junit-report.xml"
     report_dir = Application.get_env :junit_formatter, :report_dir, Mix.Project.app_path
@@ -137,7 +140,7 @@ defmodule JUnitFormatter do
   # PRIVATE ------------
 
   defp adjust_case_stats(%ExUnit.Test{} = test, config) do
-    stats = Keyword.get config, test.case,  %JUnitFormatter.TestCaseStats{}
+    stats = Keyword.get(config, test.case,  %JUnitFormatter.TestCaseStats{})
     stats = %{stats | tests: stats.tests + 1}
     stats = %{stats | time: stats.time + test.time}
     %{stats | test_cases: [test | stats.test_cases]}
@@ -161,14 +164,14 @@ defmodule JUnitFormatter do
                   failures: stats.failures,
                   name: name,
                   tests: stats.tests,
-                  time: stats.time |> format_time],
+                  time: stats.time |> format_time()],
      for test <- stats.test_cases do
        generate_testcases(test)
      end
     }
   end
 
-  defp us_to_ms(us), do: div(us, 10000)
+  defp us_to_ms(us), do: div(us, 10_000)
 
   defp format_ms(ms) do
     if ms < 10 do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Formatter.Mixfile do
   use Mix.Project
 
-  @version "1.2.0"
+  @version "1.3.0"
 
   def project do
     [app: :junit_formatter,
@@ -27,10 +27,11 @@ defmodule Formatter.Mixfile do
 
   defp deps do
     [
-      {:earmark, "~> 1.0", only: :docs},
+      {:earmark, "~> 1.1", only: :docs},
       {:ex_doc, "~> 0.14", only: :docs},
-      {:excoveralls, "~> 0.5", only: :test},
-      {:credo, "~> 0.5", only: [:dev, :test]}
+      {:excoveralls, "~> 0.6", only: :test},
+      {:exjsx, "~> 4.0", only: :test, override: true},
+      {:credo, "~> 0.6", only: [:dev, :test]}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -4,10 +4,10 @@
   "earmark": {:hex, :earmark, "1.1.0", "8c2bf85d725050a92042bc1edf362621004d43ca6241c756f39612084e95487f", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "excoveralls": {:hex, :excoveralls, "0.6.1", "9e946b6db84dba592f47632157ecd135a46384b98a430fd16007dc910c70348b", [:mix], [{:exjsx, "~> 3.0", [hex: :exjsx, optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, optional: false]}]},
-  "exjsx": {:hex, :exjsx, "3.2.1", "1bc5bf1e4fd249104178f0885030bcd75a4526f4d2a1e976f4b428d347614f0f", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, optional: false]}]},
+  "exjsx": {:hex, :exjsx, "4.0.0", "60548841e0212df401e38e63c0078ec57b33e7ea49b032c796ccad8cde794b5c", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, optional: false]}]},
   "hackney": {:hex, :hackney, "1.6.5", "8c025ee397ac94a184b0743c73b33b96465e85f90a02e210e86df6cbafaa5065", [:rebar3], [{:certifi, "0.7.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
   "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
-  "jsx": {:hex, :jsx, "2.8.1", "1453b4eb3615acb3e2cd0a105d27e6761e2ed2e501ac0b390f5bbec497669846", [:mix, :rebar3], []},
+  "jsx": {:hex, :jsx, "2.8.2", "7acc7d785b5abe8a6e9adbde926a24e481f29956dd8b4df49e3e4e7bcc92a018", [:mix, :rebar3], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []}}

--- a/test/formatter_test.exs
+++ b/test/formatter_test.exs
@@ -95,9 +95,24 @@ defmodule FormatterTest do
       end
     end
 
-    output = run_and_capture_output |> strip_time_and_line_number
+    output = run_and_capture_output() |> strip_time_and_line_number()
 
     assert output =~ "<testcase classname=\"Elixir.FormatterTest.RaiseWithNoMessage\" name=\"test it raises without message\" ><failure message=\"error: %FormatterTest.NilMessageError{customMessage: &quot;A custom error occured !&quot;, message: nil}\">    test/formatter_test.exs FormatterTest.RaiseWithNoMessage.\"test it raises without message\"/1\n</failure></testcase>"
+  end
+
+  test "it can count skipped tests" do
+    defmodule SkipTest do
+      use ExUnit.Case
+
+      @tag :skip
+      test "it just skips" do
+        :ok
+      end
+    end
+
+    output = run_and_capture_output() |> strip_time_and_line_number()
+
+    assert output =~ "<testcase classname=\"Elixir.FormatterTest.SkipTest\" name=\"test it just skips\" ><skipped/></testcase>"
   end
 
   test "it can format time" do
@@ -131,7 +146,7 @@ defmodule FormatterTest do
   end
 
   defp run_and_capture_output do
-    ExUnit.configure formatters: [JUnitFormatter]
+    ExUnit.configure(formatters: [JUnitFormatter], exclude: :skip)
 
     # Elixir 1.3 introduced this function changing the behaviour of custom calls
     # to ExUnit.run. We need to call this function if available.


### PR DESCRIPTION
Adds a test that the formatter can handle skipped tests.

This also fixes some other credo warnings.