### PR TITLE
Add test case for subprocesses crashing

### DIFF
--- a/lib/formatter.ex
+++ b/lib/formatter.ex
@@ -204,7 +204,12 @@ defmodule JUnitFormatter do
         %{message: message} -> message
         other -> inspect(other)
       end
-    [{:failure, [message: Atom.to_string(kind) <> ": " <> message], [String.to_charlist(formatted_stack)]}]
+    exception_kind =
+      case kind do
+        error when is_atom(error) -> Atom.to_string(error)
+        other -> inspect(other)
+      end
+    [{:failure, [message: exception_kind <> ": " <> message], [String.to_charlist(formatted_stack)]}]
   end
   defp generate_test_body(%ExUnit.Test{state: {:invalid, module}}) do
     [{:error, [message: "Invalid module #{inspect module}"], []}]

--- a/test/formatter_test.exs
+++ b/test/formatter_test.exs
@@ -82,6 +82,22 @@ defmodule FormatterTest do
     assert output =~ "<testcase classname=\"Elixir.FormatterTest.RaiseWithNoReason\" name=\"test it raises without reason\" ><failure message=\"throw: nil\">    test/formatter_test.exs FormatterTest.RaiseWithNoReason.\"test it raises without reason\"/1\n</failure></testcase>"
   end
 
+  @tag :capture_log
+  test "it can handle crashed process" do
+    defmodule RaiseCrash do
+      use ExUnit.Case
+
+      test "it crashes" do
+        spawn_link(fn -> raise ArgumentError end)
+        receive do end
+      end
+    end
+
+    output = run_and_capture_output() |> strip_time_and_line_number
+
+    assert output =~ ~r/<testcase classname=\"Elixir.FormatterTest.RaiseCrash\" name=\"test it crashes\" ><failure message=\"{:EXIT, #PID&lt;0.\d+.0>}: {%ArgumentError{message: &quot;argument error&quot;}, .*?\">\n<\/failure><\/testcase>/
+  end
+
   test "it can handle empty message" do
     defmodule NilMessageError do
       defexception [message: nil, customMessage: "A custom error occured !"]


### PR DESCRIPTION
fixes #29 

cf. https://github.com/elixir-lang/elixir/blob/master/lib/elixir/lib/exception.ex#L26 defines `{:EXIT, pid}` as a valid kind which can't be handled by `Atom.to_string/1`