### PR TITLE
Handle unicode in test names

### DIFF
--- a/lib/formatter.ex
+++ b/lib/formatter.ex
@@ -72,7 +72,7 @@ defmodule JUnitFormatter do
     # save the report in an xml file
     file_name = get_file_name(config)
     file = File.open!(file_name, [:write])
-    IO.binwrite(file, result)
+    IO.write(file, result)
     File.close(file)
 
     if Application.get_env(:junit_formatter, :print_report_file, false) do

--- a/lib/formatter.ex
+++ b/lib/formatter.ex
@@ -188,7 +188,7 @@ defmodule JUnitFormatter do
       :testcase,
       [
         classname: Atom.to_charlist(test.case),
-        name: Atom.to_charlist(test.name),
+        name: Atom.to_string(test.name),
         time: test.time |> us_to_ms |> format_ms
       ],
       generate_test_body(test)

--- a/test/formatter_test.exs
+++ b/test/formatter_test.exs
@@ -141,6 +141,22 @@ defmodule FormatterTest do
              "<testcase classname=\"Elixir.FormatterTest.SkipTest\" name=\"test it just skips\" ><skipped/></testcase>"
   end
 
+
+  test "it can include unicode in test names" do
+    defmodule UnicodeTest do
+      use ExUnit.Case
+
+      test "make sure 3 ≤ 4" do
+        :ok
+      end
+    end
+
+    output = run_and_capture_output() |> strip_time_and_line_number
+
+    assert output =~
+             "<testcase classname=\"Elixir.FormatterTest.UnicodeTest\" name=\"test make sure 3 ≤ 4\" />"
+  end
+
   test "it can format time" do
     assert JUnitFormatter.format_time(1_000_000) == "1.0"
     assert JUnitFormatter.format_time(10000) == "0.01"


### PR DESCRIPTION
`Atom.to_charlist` does not handle unicode well, but `Atom.to_string` seems to.

Atoms can include unicode as of a recent version of Elixir. We had added a `≤` in the name of one of our tests recently, which caused the xml file output by junit-formatter to be empty.