### PR TITLE
Converts String to utf8 charlist, instead of unicode

### DIFF
--- a/lib/formatter.ex
+++ b/lib/formatter.ex
@@ -207,7 +207,7 @@ defmodule JUnitFormatter do
     body =
       test
       |> ExUnit.Formatter.format_test_failure(failures, idx, :infinity, fn _, msg -> msg end)
-      |> String.to_charlist()
+      |> :erlang.binary_to_list()
 
     [{:failure, [message: message(failures)], [body]}]
   end


### PR DESCRIPTION
I had a issue with special chars like öäü. As soon as they appeard in a test content, for example as error message, those characters corrupted the junit xml, since were invalid utf8 characters (�)

Here's a example of the xmllint output:
```
 parser error : Input is not proper UTF-8, indicate encoding !
Bytes: 0xFC 0x73 0x69 0x6E
tionships&quot; => %{}, &quot;type&quot; => &quot;invoice&quot;}">  1) test DE-B
```

After a little bit of debugging, I've found the issue. 
String.to_charlist will convert the String to a list of Unicode representivs but the xmerl_lib expects utf8 characters