### PR TITLE
Add configurable `include_filename?` setting to allow <testcase>s to include the test file path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,18 +69,21 @@ The JUnit style XML report for this project looks like this:
 `JUnitFormatter` accepts 4 options that can be passed in config.exs (or equivalent environment configuration for tests):
 
 - `print_report_file` (boolean - default `false`): tells formatter if you want to see the path where the file is being written to in the console. This might help you debug where the file is. By default it writes the report to the `Mix.Project.app_path` folder. This ensures compatibility with umbrella apps.
-- `report_file` (binary - default `"test-junit-report.xml"`): the name of the file to write to. It must contain the extension. 99% of the time you will want the extension to be `.xml`, but if you don't you can pass any extension (though the contents of the file will be an xml document). 
+- `report_file` (binary - default `"test-junit-report.xml"`): the name of the file to write to. It must contain the extension. 99% of the time you will want the extension to be `.xml`, but if you don't you can pass any extension (though the contents of the file will be an xml document).
 - `report_dir` (binary - default `Mix.Project.app_path()`): the directory to which the formatter will write the report. Do not end it with a slash. **IMPORTANT!!** `JUnitFormatter` will **NOT** create the directory. If you are pointing to a directory that is outside _build then it is your duty to clean it and to be sure it exists.
 - `prepend_project_name?` (boolean - default `false`): tells if the report file should have the name of the project as a prefix. See the "Umbrella" part of the documentation.
 
-Example configuration: 
+- `include_filename?` (boolean - default `false`): dictates whether `<testcase>`s in the XML report should include a "file" attribute of the relative path to the file of the test. Note that this defaults to false because not all JUnit ingesters will accept a file attribute.  
+
+Example configuration:
 
 ``` elixir
 config :junit_formatter,
   report_file: "report_file_test.xml",
   report_dir: "/tmp",
   print_report_file: true,
-  prepend_project_name?: true
+  prepend_project_name?: true,
+  include_filename?: true
 ```
 
 This would generate the report at: `/tmp/myapp-report_file_test.xml`.

--- a/lib/formatter.ex
+++ b/lib/formatter.ex
@@ -185,13 +185,17 @@ defmodule JUnitFormatter do
   end
 
   defp generate_testcases(test, idx) do
+    attrs = [
+      classname: Atom.to_string(test.case),
+      name: Atom.to_string(test.name),
+      time: format_time(test.time)
+    ]
+
+    attrs = maybe_add_filename(attrs, test.tags.file)
+
     {
       :testcase,
-      [
-        classname: Atom.to_string(test.case),
-        name: Atom.to_string(test.name),
-        time: format_time(test.time)
-      ],
+      attrs,
       generate_test_body(test, idx)
     }
   end
@@ -220,4 +224,12 @@ defmodule JUnitFormatter do
   defp message({:error, reason, _}), do: "error: #{Exception.message(reason)}"
   defp message({type, reason, _}) when is_atom(type), do: "#{type}: #{inspect(reason)}"
   defp message({type, reason, _}), do: "#{inspect(type)}: #{inspect(reason)}"
+
+  defp maybe_add_filename(attrs, path) do
+    if Application.get_env(:junit_formatter, :include_filename?) do
+      Keyword.put(attrs, :file, Path.relative_to_cwd(path))
+    else
+      attrs
+    end
+  end
 end

--- a/test/formatter_test.exs
+++ b/test/formatter_test.exs
@@ -239,6 +239,28 @@ defmodule FormatterTest do
         assert "This error contains unicodes in failure message -> öäü ≤" =
                  String.Chars.to_string(chars)
       end
+
+      test "has file attribute when configured to" do
+        defsuite do
+          test "it will fail", do: assert(false)
+        end
+
+        put_config(:include_filename?, true)
+        output = run_and_capture_output()
+
+        assert xpath(output, ~x{//testsuite/testcase/@file}s) == "test/formatter_test.exs"
+      end
+
+      test "does not have file attribute when not configured to" do
+        defsuite do
+          test "it will fail", do: assert(false)
+        end
+
+        put_config(:include_filename?, false)
+        output = run_and_capture_output()
+
+        assert xpath(output, ~x{//testsuite/testcase/@file}s) == ""
+      end
     end
   end
 


### PR DESCRIPTION
Hello! I'm submitting this PR because I ran into an issue on CircleCI where their `split-by=timings` option required the ingested JUnit XML to include a filename. I have tested the generated XML on my forked branch, and it *does fix* the CircleCI timings problem for Elixir.

However, I didn't want to force it to be true by default here because I found a few issues where including the `file` attribute caused [issues with the XML parser](https://github.com/sj26/rspec_junit_formatter/pull/70).

Let me know if you find any issues with the code. 