### PR TITLE
Make it work with Elixir 1.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
             otp: 21.3.8.20
           - elixir: 1.11.x
             otp: 23.2.x
+          - elixir: 1.12.x
+            otp: 24.0.x
     env:
       MIX_ENV: test
     steps:

--- a/lib/formatter.ex
+++ b/lib/formatter.ex
@@ -65,7 +65,7 @@ defmodule JUnitFormatter do
   end
 
   @impl true
-  def handle_cast({:suite_finished, _run_us, _load_us}, config) do
+  def handle_cast({:suite_finished, %{async: _, load: _, run: _}}, config) do
     # do the real magic
     suites = Enum.map(config.cases, &generate_testsuite_xml(&1, config.properties))
     # wrap result in a root node (not adding any attribute to root)


### PR DESCRIPTION
With Elixir 1.12 the `:suite_finished` cast has a slightly different structure, meaning that junit-formatter would no longer work.
You can see it here: https://hexdocs.pm/ex_unit/ExUnit.Formatter.html#content

With this change all tests pass locally on Erlang 24.0 + Elixir 1.12-otp-24.

I also updated the `ci.yml` though I'm not sure that is correct.