### PR TITLE
Configuration for optional per-application directory prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The JUnit style XML report for this project looks like this:
 - `include_filename?` (boolean - default `false`): dictates whether `<testcase>`s in the XML report should include a "file" attribute of the relative path to the file of the test. Note that this defaults to false because not all JUnit ingesters will accept a file attribute.
 - `include_file_line?` (boolean - default `false`): only has effect when `include_filename?` is `true`. Dictates whether `file` attribute should include line of the test after a colon (e.g. `test/file_test.exs:123`).
 - `automatic_create_dir?` (boolean - default `false`): create a directory that defined in `report_dir` before writing report files.
+- `project_dir` (string - default `nil`). Specifies which directory the test file paths should be relative to within the XML. If unset or `nil`, the path to the test file is calculated relative to the current working directory.
 
 Example configuration:
 
@@ -119,11 +120,20 @@ If you want to use a consistent report filename, and instead place the reports u
 - `/tmp/my_app/report_file.xml`
 - `/tmp/another/report_file.xml`
 
+If you want to specify the paths to the test files in the report relative to the root of the umbrella project, not the individual application, then set `project_dir`. In your umbrella configuration file, at `config/test.exs`, if you set the following configuration:
+
+``` elixir
+config :junit_formatter,
+  project_dir: Path.expand("..", __DIR__)
+```
+
+Then in your report, a test file within your umbrella at `apps/my_app/test/my_app_test.exs` will be specified within the report as `apps/my_app/test/my_app_test.exs`. If you leave `project_dir` unset it would instead be specified as `test/my_app_test.exs`.
+
 ## Integrating on CI systems
 
 Most CIs have a way for uploading test reports. This is a nice way to understand what failed on your build. Most of them use the JUnit report file format to provide this feature.
 
-- [CircleCI](https://circleci.com/docs/2.0/language-elixir/) example configuration provides JUnit reports integration. For umbrella projects, if you set `use_project_subdirectory?: true` then CircleCI will provide reports per application.
+- [CircleCI](https://circleci.com/docs/2.0/language-elixir/) example configuration provides JUnit reports integration. For umbrella projects, if you set `use_project_subdirectory?: true` then CircleCI will provide reports per application. It is also advisable to set `project_dir` for umbrella projects so that files will be reported with their full path.
 
 ## LICENSE
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The JUnit style XML report for this project looks like this:
 - `report_file` (binary - default `"test-junit-report.xml"`): the name of the file to write to. It must contain the extension. 99% of the time you will want the extension to be `.xml`, but if you don't you can pass any extension (though the contents of the file will be an XML document).
 - `report_dir` (binary - default `Mix.Project.app_path()`): the directory to which the formatter will write the report. Do not end it with a slash. **IMPORTANT!!** `JUnitFormatter` will **NOT**, by default, create the directory. If you are pointing to a directory that is outside _build then you can set the `automatic_create_dir?` option. 
 - `prepend_project_name?` (boolean - default `false`): tells if the report file should have the name of the project as a prefix. See the "Umbrella" part of the documentation.
+- `use_project_subdirectory?` (boolean - default `false`): determines if the report file should be put into a subdirectory under `report_dir` named according to the project. If you set this then `automatic_create_dir?` will also be set to `true`. See the "Umbrella" part of the documentation.
 - `include_filename?` (boolean - default `false`): dictates whether `<testcase>`s in the XML report should include a "file" attribute of the relative path to the file of the test. Note that this defaults to false because not all JUnit ingesters will accept a file attribute.
 - `include_file_line?` (boolean - default `false`): only has effect when `include_filename?` is `true`. Dictates whether `file` attribute should include line of the test after a colon (e.g. `test/file_test.exs:123`).
 - `automatic_create_dir?` (boolean - default `false`): create a directory that defined in `report_dir` before writing report files.
@@ -113,12 +114,16 @@ The next one will do the same **OVERRIDING** the first one. So, in order to avoi
 - `/tmp/my_app-report_file.xml`
 - `/tmp/another-report_file.xml`
 
+If you want to use a consistent report filename, and instead place the reports under a subdirectory per application, then set the `use_project_subdirectory?` configuration flag to `true`. Using this configuration would result in the following file layout:
+
+- `/tmp/my_app/report_file.xml`
+- `/tmp/another/report_file.xml`
+
 ## Integrating on CI systems
 
 Most CIs have a way for uploading test reports. This is a nice way to understand what failed on your build. Most of them use the JUnit report file format to provide this feature.
 
-- [CircleCI](https://circleci.com/docs/2.0/language-elixir/) example configuration provides JUnit reports integration
-
+- [CircleCI](https://circleci.com/docs/2.0/language-elixir/) example configuration provides JUnit reports integration. For umbrella projects, if you set `use_project_subdirectory?: true` then CircleCI will provide reports per application.
 
 ## LICENSE
 

--- a/lib/formatter.ex
+++ b/lib/formatter.ex
@@ -129,14 +129,17 @@ defmodule JUnitFormatter do
   def get_report_file_path do
     report_file = Application.get_env(:junit_formatter, :report_file, "test-junit-report.xml")
 
-    Path.join([report_dir(), report_file])
+    prepend = Application.get_env(:junit_formatter, :prepend_project_name?, false)
+    prefix = if prepend, do: "#{Mix.Project.config()[:app]}-", else: ""
+
+    Path.join([report_dir(), prefix <> report_file])
   end
 
   defp report_dir do
-    prepend = Application.get_env(:junit_formatter, :prepend_project_name?, false)
+    subdir = Application.get_env(:junit_formatter, :use_project_subdirectory?, false)
 
     report_dir = Application.get_env(:junit_formatter, :report_dir, Mix.Project.app_path())
-    prefix = if prepend, do: "#{Mix.Project.config()[:app]}", else: ""
+    prefix = if subdir, do: "#{Mix.Project.config()[:app]}", else: ""
 
     Path.join([report_dir, prefix])
   end

--- a/lib/formatter.ex
+++ b/lib/formatter.ex
@@ -131,9 +131,9 @@ defmodule JUnitFormatter do
 
     report_file = Application.get_env(:junit_formatter, :report_file, "test-junit-report.xml")
     report_dir = Application.get_env(:junit_formatter, :report_dir, Mix.Project.app_path())
-    prefix = if prepend, do: "#{Mix.Project.config()[:app]}-", else: ""
+    prefix = if prepend, do: "#{Mix.Project.config()[:app]}", else: ""
 
-    Path.join(report_dir, prefix <> report_file)
+    Path.join([report_dir, prefix, report_file])
   end
 
   # PRIVATE ------------

--- a/lib/formatter.ex
+++ b/lib/formatter.ex
@@ -256,7 +256,7 @@ defmodule JUnitFormatter do
 
   defp maybe_add_filename(attrs, path, line) do
     if Application.get_env(:junit_formatter, :include_filename?) do
-      path = Path.relative_to_cwd(path)
+      path = relative_path(path)
 
       file =
         if Application.get_env(:junit_formatter, :include_file_line?) do
@@ -269,5 +269,10 @@ defmodule JUnitFormatter do
     else
       attrs
     end
+  end
+
+  defp relative_path(path) do
+    root = Application.get_env(:junit_formatter, :project_dir, nil) || File.cwd!()
+    Path.relative_to(path, root)
   end
 end

--- a/lib/formatter.ex
+++ b/lib/formatter.ex
@@ -55,9 +55,7 @@ defmodule JUnitFormatter do
 
   @impl true
   def init(opts) do
-    automatic_create_dir? = Application.get_env(:junit_formatter, :automatic_create_dir?, false)
-
-    if automatic_create_dir? do
+    if automatic_create_dir?() do
       :ok = File.mkdir_p(report_dir())
     end
 
@@ -142,6 +140,13 @@ defmodule JUnitFormatter do
     prefix = if subdir, do: "#{Mix.Project.config()[:app]}", else: ""
 
     Path.join([report_dir, prefix])
+  end
+
+  defp automatic_create_dir? do
+    automatic_create_dir? = Application.get_env(:junit_formatter, :automatic_create_dir?, false)
+    use_project_subdir? = Application.get_env(:junit_formatter, :use_project_subdirectory?, false)
+
+    automatic_create_dir? || use_project_subdir?
   end
 
   # PRIVATE ------------

--- a/lib/formatter.ex
+++ b/lib/formatter.ex
@@ -56,9 +56,9 @@ defmodule JUnitFormatter do
   @impl true
   def init(opts) do
     automatic_create_dir? = Application.get_env(:junit_formatter, :automatic_create_dir?, false)
+
     if automatic_create_dir? do
-      report_dir = Application.get_env(:junit_formatter, :report_dir, Mix.Project.app_path())
-      :ok = File.mkdir_p(report_dir)
+      :ok = File.mkdir_p(report_dir())
     end
 
     {:ok,
@@ -127,13 +127,18 @@ defmodule JUnitFormatter do
   """
   @spec get_report_file_path() :: String.t()
   def get_report_file_path do
+    report_file = Application.get_env(:junit_formatter, :report_file, "test-junit-report.xml")
+
+    Path.join([report_dir(), report_file])
+  end
+
+  defp report_dir do
     prepend = Application.get_env(:junit_formatter, :prepend_project_name?, false)
 
-    report_file = Application.get_env(:junit_formatter, :report_file, "test-junit-report.xml")
     report_dir = Application.get_env(:junit_formatter, :report_dir, Mix.Project.app_path())
     prefix = if prepend, do: "#{Mix.Project.config()[:app]}", else: ""
 
-    Path.join([report_dir, prefix, report_file])
+    Path.join([report_dir, prefix])
   end
 
   # PRIVATE ------------

--- a/test/formatter_test.exs
+++ b/test/formatter_test.exs
@@ -309,8 +309,16 @@ defmodule FormatterTest do
     end
 
     test "it can prepend the project name to the report file" do
-      # Ensure defaults
       put_config(:prepend_project_name?, true)
+
+      assert get_config(:report_file) == "report_file_test.xml"
+
+      assert JUnitFormatter.get_report_file_path() ==
+               "#{Mix.Project.app_path()}/junit_formatter-report_file_test.xml"
+    end
+
+    test "it can put the report file in a project sub-directory" do
+      put_config(:use_project_subdirectory?, true)
 
       assert get_config(:report_file) == "report_file_test.xml"
 
@@ -328,6 +336,19 @@ defmodule FormatterTest do
 
       assert File.exists?(tmp_dir)
       File.rmdir!(tmp_dir)
+    end
+
+    test "create sub-directory at init" do
+      tmp_dir = Path.join([Mix.Project.app_path(), System.tmp_dir!()])
+
+      put_config(:use_project_subdirectory?, true)
+      put_config(:automatic_create_dir?, true)
+      put_config(:report_dir, tmp_dir)
+
+      {:ok, _} = JUnitFormatter.init(seed: 1)
+
+      assert File.exists?(Path.join(tmp_dir, "junit_formatter"))
+      File.rm_rf!(tmp_dir)
     end
 
     test "create exist directory at init" do
@@ -352,6 +373,7 @@ defmodule FormatterTest do
     put_config(:prepend_project_name?, false)
     put_config(:include_file_line?, false)
     put_config(:automatic_create_dir?, false)
+    put_config(:use_project_subdirectory?, false)
   end
 
   defp get_config(name), do: Application.get_env(:junit_formatter, name)

--- a/test/formatter_test.exs
+++ b/test/formatter_test.exs
@@ -315,7 +315,7 @@ defmodule FormatterTest do
       assert get_config(:report_file) == "report_file_test.xml"
 
       assert JUnitFormatter.get_report_file_path() ==
-               "#{Mix.Project.app_path()}/junit_formatter-report_file_test.xml"
+               "#{Mix.Project.app_path()}/junit_formatter/report_file_test.xml"
     end
 
     test "create directory at init" do

--- a/test/formatter_test.exs
+++ b/test/formatter_test.exs
@@ -351,6 +351,19 @@ defmodule FormatterTest do
       File.rm_rf!(tmp_dir)
     end
 
+    test "always create sub-directory at init even without automatic_create_dir?" do
+      tmp_dir = Path.join([Mix.Project.app_path(), System.tmp_dir!()])
+
+      put_config(:use_project_subdirectory?, true)
+      put_config(:automatic_create_dir?, false)
+      put_config(:report_dir, tmp_dir)
+
+      {:ok, _} = JUnitFormatter.init(seed: 1)
+
+      assert File.exists?(Path.join(tmp_dir, "junit_formatter"))
+      File.rm_rf!(tmp_dir)
+    end
+
     test "create exist directory at init" do
       tmp_dir = Path.join([Mix.Project.app_path(), System.tmp_dir!()])
 

--- a/test/formatter_test.exs
+++ b/test/formatter_test.exs
@@ -278,6 +278,22 @@ defmodule FormatterTest do
 
         assert xpath(output, ~x{//testsuite/testcase/@file}s) == ""
       end
+
+      test "makes path relative to project_dir if set" do
+        defsuite do
+          test "it will fail", do: assert(false)
+        end
+
+        parent_dir = Path.expand("../..", __DIR__)
+        repo_dir_name = Path.expand("..", __DIR__) |> Path.basename()
+
+        put_config(:include_filename?, true)
+        put_config(:project_dir, parent_dir)
+        output = run_and_capture_output()
+
+        assert xpath(output, ~x{//testsuite/testcase/@file}s) ==
+                 "#{repo_dir_name}/test/formatter_test.exs"
+      end
     end
   end
 
@@ -387,6 +403,7 @@ defmodule FormatterTest do
     put_config(:include_file_line?, false)
     put_config(:automatic_create_dir?, false)
     put_config(:use_project_subdirectory?, false)
+    put_config(:project_dir, nil)
   end
 
   defp get_config(name), do: Application.get_env(:junit_formatter, name)


### PR DESCRIPTION
This improves integration with e.g. CircleCI, which expects report files to be placed in a sub-directory and will use the sub-directory name as a label for the test results.

With this new `use_project_subdirectory?` configuration, report files will be named as `"#{report_dir}/#{application_name}/#{report_file}"`.

If this config is turned on then I also added a default to automatically create the report dir, as otherwise I think it would just error for everyone on the first use.