### PR TITLE
Don't store logs for test cases to reduce memory usage

### DIFF
--- a/lib/formatter.ex
+++ b/lib/formatter.ex
@@ -168,16 +168,18 @@ defmodule JUnitFormatter do
   end
 
   defp adjust_case_stats(%ExUnit.Test{case: name, time: time} = test, type, state) do
+    test_without_logs = %ExUnit.Test{test | logs: ""}
+
     cases =
       Map.update(
         state.cases,
         name,
-        struct(Stats, [{type, 1}, test_cases: [test], time: time, tests: 1]),
+        struct(Stats, [{type, 1}, test_cases: [test_without_logs], time: time, tests: 1]),
         fn stats ->
           stats =
             struct(
               stats,
-              test_cases: [test | stats.test_cases],
+              test_cases: [test_without_logs | stats.test_cases],
               time: stats.time + time,
               tests: stats.tests + 1
             )


### PR DESCRIPTION
Storing every test case can take up a lot of memory, especially when `capture_log: true` is used in ExUnit. This MR removes the log information since it's unused anyway.

Thanks a lot for a great project! ❤️ 