### PR TITLE
Write testsuite to file after each module is done

### DIFF
--- a/test/formatter_test.exs
+++ b/test/formatter_test.exs
@@ -380,14 +380,18 @@ defmodule FormatterTest do
       File.rm_rf!(tmp_dir)
     end
 
-    @tag :tmp_dir
-    test "create exist directory at init", %{tmp_dir: tmp_dir} do
+    test "create exist directory at init" do
+      tmp_dir = Path.join([Mix.Project.app_path(), System.tmp_dir!()])
+
       put_config(:automatic_create_dir?, true)
       put_config(:report_dir, tmp_dir)
+
+      File.mkdir!(tmp_dir)
 
       {:ok, _} = JUnitFormatter.init(seed: 1)
 
       assert File.exists?(tmp_dir)
+      File.rm_rf!(tmp_dir)
     end
   end
 

--- a/test/formatter_test.exs
+++ b/test/formatter_test.exs
@@ -351,7 +351,7 @@ defmodule FormatterTest do
       {:ok, _} = JUnitFormatter.init(seed: 1)
 
       assert File.exists?(tmp_dir)
-      File.rmdir!(tmp_dir)
+      File.rm_rf!(tmp_dir)
     end
 
     test "create sub-directory at init" do
@@ -380,18 +380,14 @@ defmodule FormatterTest do
       File.rm_rf!(tmp_dir)
     end
 
-    test "create exist directory at init" do
-      tmp_dir = Path.join([Mix.Project.app_path(), System.tmp_dir!()])
-
+    @tag :tmp_dir
+    test "create exist directory at init", %{tmp_dir: tmp_dir} do
       put_config(:automatic_create_dir?, true)
       put_config(:report_dir, tmp_dir)
-
-      File.mkdir!(tmp_dir)
 
       {:ok, _} = JUnitFormatter.init(seed: 1)
 
       assert File.exists?(tmp_dir)
-      File.rmdir!(tmp_dir)
     end
   end
 


### PR DESCRIPTION
Hello @victorolinasc !

After #47 our test suite is using less memory. However even with that change (and https://github.com/elixir-lang/elixir/pull/11754 for the `CLIFormatter`), our big monolith's test suite with 12k+ test cases can hit the memory limits on (beefy!) CI runners. So this PR is my attempt at cutting out even more memory from `JUnitFormatter`. Instead of keeping things around until the end of the suite, this version will write each junit testsuite out to file as soon as a module is done. What do you think?

Thanks for a great project ❤️ 