### PR TITLE
Add handling of :skipped atom when using ExUnit >= 1.7.0

### DIFF
--- a/lib/formatter.ex
+++ b/lib/formatter.ex
@@ -207,6 +207,7 @@ defmodule JUnitFormatter do
       [
         errors: stats.errors,
         failures: stats.failures,
+        skipped: stats.skipped,
         name: name,
         tests: stats.tests,
         time: format_time(stats.time)

--- a/lib/formatter.ex
+++ b/lib/formatter.ex
@@ -87,7 +87,7 @@ defmodule JUnitFormatter do
     {:noreply, config}
   end
 
-  def handle_cast({:test_finished, %ExUnit.Test{state: {:skip, _}} = test}, config) do
+  def handle_cast({:test_finished, %ExUnit.Test{state: {tag, _}} = test}, config) when tag in [:skip, :skipped] do
     config = adjust_case_stats(test, :skipped, config)
 
     {:noreply, config}
@@ -234,7 +234,7 @@ defmodule JUnitFormatter do
   defp generate_test_body(%ExUnit.Test{state: nil}, _idx), do: []
 
   defp generate_test_body(%ExUnit.Test{state: {atom, message}}, _idx)
-       when atom in ~w[skip excluded]a do
+       when atom in ~w[skip skipped excluded]a do
     [{:skipped, [message: message], []}]
   end
 


### PR DESCRIPTION
Cf. issue #49 for details.